### PR TITLE
Revert version to 2.10.0

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -26,9 +26,9 @@ include $(BOLOS_SDK)/Makefile.defines
 
 # Main app configuration
 APPNAME = "Cosmos"
-APPVERSION_M=3
-APPVERSION_N=0
-APPVERSION_P=1
+APPVERSION_M=2
+APPVERSION_N=10
+APPVERSION_P=0
 
 APPPATH = "44'/118'"
 APP_LOAD_PARAMS = --appFlags 0x200 --delete $(COMMON_LOAD_PARAMS) --path $(APPPATH)


### PR DESCRIPTION
The API has not changed, so to avoid integration issues, we are reverting the version back to v2.10.0.
This means that wallets and integrations libraries do not need to be adjusted.
