### PR TITLE
Enable coin type for ecosystem chains

### DIFF
--- a/app/src/common/app_main.c
+++ b/app/src/common/app_main.c
@@ -100,7 +100,7 @@ void extractHDPath(uint32_t rx, uint32_t offset) {
 
     // Check values
     if (hdPath[0] != HDPATH_0_DEFAULT ||
-        hdPath[1] != HDPATH_1_DEFAULT ||
+        // hdPath[1] != HDPATH_1_DEFAULT ||
         hdPath[3] != HDPATH_3_DEFAULT) {
         THROW(APDU_CODE_DATA_INVALID);
     }


### PR DESCRIPTION
Enable coin type for ecosystem chains which do not use 118. like desmos 852,  Band 494, Luna: 330