### PR TITLE
Update APDUSPEC and TXSPEC

### DIFF
--- a/docs/APDUSPEC.md
+++ b/docs/APDUSPEC.md
@@ -131,7 +131,7 @@ All other packets/chunks should contain message to sign
 
 | Field   | Type      | Content     | Note                     |
 | ------- | --------- | ----------- | ------------------------ |
-| SIG     | byte (64) | Signature   |                          |
+| SIG     | byte (variable) | Signature   |                          |
 | SW1-SW2 | byte (2)  | Return code | see list of return codes |
 
 The signature data is DER encoded. The returned bytes have the following structure.

--- a/docs/APDUSPEC.md
+++ b/docs/APDUSPEC.md
@@ -134,4 +134,10 @@ All other packets/chunks should contain message to sign
 | SIG     | byte (64) | Signature   |                          |
 | SW1-SW2 | byte (2)  | Return code | see list of return codes |
 
+The signature data is DER encoded. The returned bytes have the following structure.
+
+```
+0x30 <length of whole message> <0x02> <length of R> <R> 0x2 <length of S> <S>
+```
+
 --------------

--- a/docs/TXSPEC.md
+++ b/docs/TXSPEC.md
@@ -24,10 +24,20 @@ Transactions passed to the Ledger device will be in the following format. The Le
 #### Examples
 
 ```json
+{
+  "account_number": "123",
+  "chain_id": "cosmoshub-4",
+  "fee": {
+    "amount": [{"amount": "4000", "denom": "uatom"}, ...],
+    "gas": "40000"
+  },
+  "memo": "this is a comment",
+  "msgs": [{arbitrary}],
+  "sequence": "42"
+}
 ```
 
-```json
-```
+Note, all the `{number}` values must be passed as string.
 
 #### Display Logic
 


### PR DESCRIPTION
I found two points in the docs a bit confusing.
- JSON Payload structure for signing.
- Signature bytes format.

I updated the docs with examples and little bit more details.