### PR TITLE
Increase coin denom maxsize in order to support transactions with IBC tokens

### DIFF
--- a/app/src/coin.h
+++ b/app/src/coin.h
@@ -50,7 +50,10 @@ typedef enum {
 #define COIN_DEFAULT_DENOM_FACTOR           6
 #define COIN_DEFAULT_DENOM_TRIMMING         6
 
-#define COIN_DENOM_MAXSIZE                  50
+// Coin denoms may be up to 128 characters long
+// https://github.com/cosmos/cosmos-sdk/blob/master/types/coin.go#L780
+// https://github.com/cosmos/ibc-go/blob/main/docs/architecture/adr-001-coin-source-tracing.md
+#define COIN_DENOM_MAXSIZE                  129
 #define COIN_AMOUNT_MAXSIZE                 50
 
 #define COIN_MAX_CHAINID_LEN                20

--- a/tests/testcases/manual.json
+++ b/tests/testcases/manual.json
@@ -1878,5 +1878,66 @@
       "5 | Gas : V3"
     ],
     "expert": true
+  },
+  {
+    "name": "ibc_denoms",
+    "tx": {
+      "account_number": "0",
+      "chain_id": "cosmoshub-4",
+      "fee": {
+        "amount": [
+          {
+            "amount": "5",
+            "denom": "uatom"
+          }
+        ],
+        "gas": "10000"
+      },
+      "memo": "testmemo",
+      "msgs": [
+        {
+          "inputs": [
+            {
+              "address": "cosmosaccaddr1d9h8qat5e4ehc5",
+              "coins": [
+                {
+                  "amount": "10",
+                  "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+                }
+              ]
+            }
+          ],
+          "outputs": [
+            {
+              "address": "cosmosaccaddr1da6hgur4wse3jx32",
+              "coins": [
+                {
+                  "amount": "10",
+                  "denom": "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "sequence": "1"
+    },
+    "parsingErr": "No error",
+    "validationErr": "No error",
+    "expected": [
+      "0 | Chain ID : cosmoshub-4",
+      "1 | Account : 0",
+      "2 | Sequence : 1",
+      "3 | Source Address : cosmosaccaddr1d9h8qat5e4ehc5",
+      "4 | Source Coins [1/2] : 10 ibc/27394FB092D2ECCD56123C74F36E4C1F",
+      "4 | Source Coins [2/2] : 926001CEADA9CA97EA622B25F41E5EB2",
+      "5 | Dest Address : cosmosaccaddr1da6hgur4wse3jx32",
+      "6 | Dest Coins [1/2] : 10 ibc/27394FB092D2ECCD56123C74F36E4C1F",
+      "6 | Dest Coins [2/2] : 926001CEADA9CA97EA622B25F41E5EB2",
+      "7 | Memo : testmemo",
+      "8 | Fee : 5 uatom",
+      "9 | Gas : 10000"
+    ],
+    "expert": true
   }
 ]


### PR DESCRIPTION
## Description
Currently, signing any transaction with an ibc token results in unrecognized error code due to the current coin denom maxsize validation of 50 characters including the null byte.

IBC denoms, such as `ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2`, are 68 characters in length, and the cosmos-sdk supports denominations up to 128 characters in length.

⚠️ This is currently blocking ledger users that have updated to the latest app version from managing their IBC funds on all cosmos chains that use app.

## Changes
This PR adds a failing test with an example transaction containing an ibc denom, and then increases the denom max length to 129 (128 characters + null byte) to pass the test.

## Testing
`make cpp_test` and `make zemu_test` both passed locally.

I also used `make load` and tested I was able to successfully sign transactions with ibc denoms on the command line and from the browser with this PR.