### PR TITLE
app/src: properly log num_items value for addr_getNumItems

### DIFF
--- a/app/src/addr.c
+++ b/app/src/addr.c
@@ -28,8 +28,9 @@ zxerr_t addr_getNumItems(uint8_t *num_items) {
     if (app_mode_expert()) {
         zemu_log("num_items 2\n");
         *num_items = 2;
+    } else {
+        zemu_log("num_items 1\n");
     }
-    zemu_log("num_items 1\n");
     return zxerr_ok;
 }
 


### PR DESCRIPTION
This change fixes a bug in which "num_items 1\n" was unconditionally
and incorrectly being logged even when in expert mode, for which the
value was changed to 2; this incorrect condition would emit 2 different
logs with different values.

Fixes #59