### PR TITLE
Typo fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ then run:
 - This project requires Ledger firmware 2.0
     - The current repository keeps track of Ledger's SDK but it is possible to override it by changing the git submodule.
 
-*Warning*: Some IDEs may not use the same python interpreter or virtual enviroment as the one you used when running `pip`.
+*Warning*: Some IDEs may not use the same python interpreter or virtual environment as the one you used when running `pip`.
 If you see conan is not found, check that you installed the package in the same interpreter as the one that launches `cmake`.
 
 ## How to build ?


### PR DESCRIPTION
### Title
**Fix typo: enviroment → environment in README.md**

### Description
This pull request corrects a typo in the README file:

- Fixed "enviroment" to "environment" for improved clarity and accuracy.

---

### Diff
```diff
- Set up your local development enviroment by following these steps.
+ Set up your local development environment by following these steps.
