### PR TITLE
Add Coreum chain into chain_config

### DIFF
--- a/app/src/chain_config.c
+++ b/app/src/chain_config.c
@@ -25,13 +25,13 @@ typedef struct {
 // To enable custom config for a new chain, just add a new entry in this array
 // with path, hrp and encoding
 static const chain_config_t chainConfig[] = {
-    {118, "cosmos", BECH32_COSMOS},  {60, "inj", BECH32_ETH},
-    {60, "evmos", BECH32_ETH},       {60, "xpla", BECH32_ETH},
-    {60, "dym", BECH32_ETH},         {60, "zeta", BECH32_ETH},
-    {60, "bera", BECH32_ETH},        {60, "human", BECH32_ETH},
-    {118, "osmos", BECH32_COSMOS},   {118, "dydx", BECH32_COSMOS},
-    {118, "mantra", BECH32_COSMOS},  {118, "xion", BECH32_COSMOS},
-    {118, "celestia", BECH32_COSMOS}};
+    {118, "cosmos", BECH32_COSMOS},   {60, "inj", BECH32_ETH},
+    {60, "evmos", BECH32_ETH},        {60, "xpla", BECH32_ETH},
+    {60, "dym", BECH32_ETH},          {60, "zeta", BECH32_ETH},
+    {60, "bera", BECH32_ETH},         {60, "human", BECH32_ETH},
+    {118, "osmos", BECH32_COSMOS},    {118, "dydx", BECH32_COSMOS},
+    {118, "mantra", BECH32_COSMOS},   {118, "xion", BECH32_COSMOS},
+    {118, "celestia", BECH32_COSMOS}, {118, "core", BECH32_COSMOS}};
 
 static const uint32_t chainConfigLen =
     sizeof(chainConfig) / sizeof(chainConfig[0]);


### PR DESCRIPTION
This PR adds [Coreum](coreum) chain support to the Ledger Cosmos App.

Although the CORE token and Coreum chain have an officially assigned coin type 990 in [SLIP-44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md), Coreum has historically used the default Cosmos Hub coin type 118 in Ledger wallets. This was a deliberate decision at launch time, as the Ledger Cosmos App only supported coin type 118 back then.

With recent changes with all ledger-related golang dependencies updated, Ledger transaction signing initiated from cored CLI now fails with the following error:
```
[APDU_CODE_DATA_INVALID] Referenced data reversibly blocked (invalidated)
```

Golang dependencies:
```
github.com/cosmos/ledger-cosmos-go v1.0.0
github.com/zondax/ledger-go v1.0.1
```

As a result, transactions from Ledger-backed Coreum wallets are currently blocked.
A **timely merge is critical for us** to unblock Ledger-based transactions and ensure a smooth user experience.
