### PR TITLE
Review fidelity and parser input validation improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,9 @@ target_link_libraries(unittests PRIVATE
 add_compile_definitions(TESTVECTORS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests/")
 add_compile_definitions(APP_TESTING=1)
 add_compile_definitions(COMPILE_TEXTUAL=1)
+# Keep the host build on the same limit as app/Makefile, so the tests exercise
+# the configuration that ships.
+add_compile_definitions(CBOR_PARSER_MAX_RECURSIONS=4)
 add_test(NAME unittests COMMAND unittests)
 set_tests_properties(unittests PROPERTIES WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests)
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -36,6 +36,10 @@ APPVERSION = "$(APPVERSION_M).$(APPVERSION_N).$(APPVERSION_P)"
 # Application source files
 APP_SOURCE_PATH += src
 CFLAGS += -I../deps/tinycbor/src
+# cbor_value_advance() recurses once per container nesting level. The screen
+# schema never needs more than one, and the default of 1024 is far beyond what
+# APP_STACK_MIN_SIZE can absorb.
+CFLAGS += -DCBOR_PARSER_MAX_RECURSIONS=4
 APP_SOURCE_PATH += ../deps/tinycbor-ledger
 APP_SOURCE_PATH += ../deps/jsmn/src
 

--- a/app/src/apdu_handler.c
+++ b/app/src/apdu_handler.c
@@ -221,9 +221,11 @@ __Z_INLINE void handleGetAddrSecp256K1(volatile uint32_t *flags,
   }
 
   if (requireConfirmation) {
-    g_tx_state = TX_STATE_REVIEWING;
     view_review_init(addr_getItem, addr_getNumItems, app_reply_address);
     view_review_show(REVIEW_ADDRESS);
+    // Claim the state only once the review is actually on screen, so a failure
+    // while bringing it up leaves the app idle instead of locked.
+    g_tx_state = TX_STATE_REVIEWING;
     *flags |= IO_ASYNCH_REPLY;
     return;
   }
@@ -285,9 +287,11 @@ __Z_INLINE void handleSign(volatile uint32_t *flags, volatile uint32_t *tx,
 #endif
 
   CHECK_APP_CANARY()
-  g_tx_state = TX_STATE_REVIEWING;
   view_review_init(tx_getItem, tx_getNumItems, app_sign);
   view_review_show(REVIEW_TXN);
+  // Claim the state only once the review is actually on screen, so a failure
+  // while bringing it up leaves the app idle instead of locked.
+  g_tx_state = TX_STATE_REVIEWING;
   *flags |= IO_ASYNCH_REPLY;
 }
 
@@ -341,10 +345,15 @@ void handleApdu(volatile uint32_t *flags, volatile uint32_t *tx, uint32_t rx) {
         break;
       }
       // Reset processing state on real errors. Preserve it on success (the
-      // handler advances the state itself) and on COMMAND_NOT_ALLOWED, where
-      // we are rejecting a concurrent command and the in-flight request must
-      // be allowed to complete.
-      if (sw != APDU_CODE_OK && sw != APDU_CODE_COMMAND_NOT_ALLOWED) {
+      // handler advances the state itself), on COMMAND_NOT_ALLOWED, where we
+      // are rejecting a concurrent command and the in-flight request must be
+      // allowed to complete, and while a review is on screen. In that last
+      // case the pending request still owns hdPath, the address encoding and
+      // the transaction buffer, all of which are read again when the user
+      // approves; only app_sign(), app_reject(), app_reply_address() and
+      // app_reply_error() may hand the state back.
+      if (sw != APDU_CODE_OK && sw != APDU_CODE_COMMAND_NOT_ALLOWED &&
+          g_tx_state != TX_STATE_REVIEWING) {
         g_tx_state = TX_STATE_IDLE;
       }
       G_io_apdu_buffer[*tx] = sw >> 8;

--- a/app/src/cbor/cbor_parser_helper.c
+++ b/app/src/cbor/cbor_parser_helper.c
@@ -47,6 +47,17 @@ static parser_error_t cbor_check_optFields(CborValue *data,
     CHECK_CBOR_MAP_ERR(cbor_value_advance(data))
 
     switch (key) {
+    case TITLE_KEY_ID:
+    case CONTENT_KEY_ID:
+      // Read for real by cbor_check_screen on the display pass; here we only
+      // step over them. Require the same definite-length text string it
+      // expects, so the advance below never has to walk into a container:
+      // cbor_value_advance() recurses once per nesting level.
+      PARSER_ASSERT_OR_ERROR(cbor_value_is_text_string(data) &&
+                                 cbor_value_is_length_known(data),
+                             parser_unexpected_type)
+      break;
+
     case INDENT_KEY_ID: {
       int tmpVal = 0;
       PARSER_ASSERT_OR_ERROR(cbor_value_is_integer(data),
@@ -66,8 +77,10 @@ static parser_error_t cbor_check_optFields(CborValue *data,
       break;
 
     default:
-      container->screen.indent = 0;
-      container->screen.expert = false;
+      // Reject rather than skip: the value of an unrecognised key can be a
+      // container of any depth, and defaulting through it would also clear
+      // options that an earlier key in the same screen already set.
+      return parser_unexpected_field;
     }
     CHECK_CBOR_MAP_ERR(cbor_value_advance(data))
   }

--- a/app/src/common/parser.h
+++ b/app/src/common/parser.h
@@ -34,7 +34,10 @@ extern "C" {
 
 // Buffer sizes for parser operations
 #define FORMATTED_AMOUNT_BUFFER_SIZE 160
-#define QUERY_KEY_BUFFER_SIZE 35
+// Must hold the longest entry in key_substitutions plus its terminator, or the
+// key path is silently clamped and the friendly label can never match. Longest
+// today is "msgs/value/msg/validator_src_address" (36).
+#define QUERY_KEY_BUFFER_SIZE 48
 
 // JSON amount object token structure constants
 // Token structure: [object, key:"amount", value, key:"denom", value]

--- a/app/src/tx_display.c
+++ b/app/src/tx_display.c
@@ -431,7 +431,7 @@ __Z_INLINE parser_error_t get_subitem_count(root_item_e root_item,
   }
 
   // Validate bounds before casting to uint8_t
-  if (tmp_num_items < 0 || tmp_num_items > UINT8_MAX) {
+  if (tmp_num_items < 0 || tmp_num_items > MAX_REVIEW_ITEMS) {
     return parser_unexpected_number_items;
   }
 
@@ -506,7 +506,7 @@ parser_error_t tx_display_numItems(uint8_t *num_items) {
   }
 
   // Reject transactions with too many items to display safely
-  if (total > UINT8_MAX) {
+  if (total > MAX_REVIEW_ITEMS) {
     return parser_unexpected_number_items;
   }
 

--- a/app/src/tx_display.c
+++ b/app/src/tx_display.c
@@ -172,6 +172,38 @@ __Z_INLINE bool address_matches_own(char *addr) {
   return true;
 }
 
+// Copies a token's bytes as they appear in the signed transaction. Decisions
+// that hide a screen must be made on these, not on the rendered value:
+// tx_getToken applies value_substitutions and returns only the first page, so
+// distinct amino types that share a friendly label ("cosmos-sdk/MsgDelegate"
+// and "/babylon.epoching.v1.MsgWrappedDelegate" both render as "Delegate")
+// would otherwise compare equal, as would two long values sharing a prefix.
+static parser_error_t get_raw_token(uint16_t token_index, char *out,
+                                    uint16_t out_len) {
+  if (out == NULL || out_len == 0 ||
+      token_index >= parser_tx_obj.tx_json.json.numberOfTokens) {
+    return parser_unexpected_value;
+  }
+
+  const int16_t start = parser_tx_obj.tx_json.json.tokens[token_index].start;
+  const int16_t end = parser_tx_obj.tx_json.json.tokens[token_index].end;
+
+  if (start < 0 || end < start) {
+    return parser_unexpected_value;
+  }
+
+  const uint16_t len = (uint16_t)(end - start);
+  if (len >= out_len) {
+    return parser_unexpected_type;
+  }
+
+  MEMZERO(out, out_len);
+  MEMCPY(out, parser_tx_obj.tx_json.tx + start, len);
+  out[len] = '\0';
+
+  return parser_ok;
+}
+
 parser_error_t tx_indexRootFields() {
   if (parser_tx_obj.tx_json.flags.cache_valid) {
     return parser_ok;
@@ -266,44 +298,60 @@ parser_error_t tx_indexRootFields() {
         // GROUPING: Message Type
         if (parser_tx_obj.tx_json.flags.msg_type_grouping &&
             is_msg_type_field(tmp_key)) {
-          // First message, initialize expected type
-          if (parser_tx_obj.tx_json.filter_msg_type_count == 0) {
+          char raw_val[INDEXING_GROUPING_REF_TYPE_SIZE];
 
-            if (strlen(tmp_val) >= sizeof(reference_msg_type)) {
-              return parser_unexpected_type;
-            }
-
-            snprintf(reference_msg_type, sizeof(reference_msg_type), "%s",
-                     tmp_val);
-            parser_tx_obj.tx_json.filter_msg_type_valid_idx = current_item_idx;
-          }
-
-          if (strcmp(reference_msg_type, tmp_val) != 0) {
-            // different values, so disable grouping
+          if (get_raw_token(ret_value_token_index, raw_val, sizeof(raw_val)) !=
+              parser_ok) {
+            // Cannot compare the signed bytes, so collapse nothing: showing a
+            // screen that could have been grouped is harmless, hiding one that
+            // differs is not.
             parser_tx_obj.tx_json.flags.msg_type_grouping = 0;
             parser_tx_obj.tx_json.filter_msg_type_count = 0;
-          }
+          } else {
+            // First message, initialize expected type
+            if (parser_tx_obj.tx_json.filter_msg_type_count == 0) {
+              snprintf(reference_msg_type, sizeof(reference_msg_type), "%s",
+                       raw_val);
+              parser_tx_obj.tx_json.filter_msg_type_valid_idx =
+                  current_item_idx;
+            }
 
-          parser_tx_obj.tx_json.filter_msg_type_count++;
+            if (strcmp(reference_msg_type, raw_val) != 0) {
+              // different values, so disable grouping
+              parser_tx_obj.tx_json.flags.msg_type_grouping = 0;
+              parser_tx_obj.tx_json.filter_msg_type_count = 0;
+            }
+
+            parser_tx_obj.tx_json.filter_msg_type_count++;
+          }
         }
 
         // GROUPING: Message From
         if (parser_tx_obj.tx_json.flags.msg_from_grouping &&
             is_msg_from_field(tmp_key)) {
-          // First message, initialize expected from
-          if (parser_tx_obj.tx_json.filter_msg_from_count == 0) {
-            snprintf(reference_msg_from, sizeof(reference_msg_from), "%s",
-                     tmp_val);
-            parser_tx_obj.tx_json.filter_msg_from_valid_idx = current_item_idx;
-          }
+          char raw_val[INDEXING_GROUPING_REF_FROM_SIZE];
 
-          if (strcmp(reference_msg_from, tmp_val) != 0) {
-            // different values, so disable grouping
+          if (get_raw_token(ret_value_token_index, raw_val, sizeof(raw_val)) !=
+              parser_ok) {
             parser_tx_obj.tx_json.flags.msg_from_grouping = 0;
             parser_tx_obj.tx_json.filter_msg_from_count = 0;
-          }
+          } else {
+            // First message, initialize expected from
+            if (parser_tx_obj.tx_json.filter_msg_from_count == 0) {
+              snprintf(reference_msg_from, sizeof(reference_msg_from), "%s",
+                       raw_val);
+              parser_tx_obj.tx_json.filter_msg_from_valid_idx =
+                  current_item_idx;
+            }
 
-          parser_tx_obj.tx_json.filter_msg_from_count++;
+            if (strcmp(reference_msg_from, raw_val) != 0) {
+              // different values, so disable grouping
+              parser_tx_obj.tx_json.flags.msg_from_grouping = 0;
+              parser_tx_obj.tx_json.filter_msg_from_count = 0;
+            }
+
+            parser_tx_obj.tx_json.filter_msg_from_count++;
+          }
         }
 
         ZEMU_LOGF(200, "[ZEMU] %s [%d/%d]", tmp_key,

--- a/app/src/tx_display.h
+++ b/app/src/tx_display.h
@@ -26,6 +26,12 @@
 extern "C" {
 #endif
 
+// The review UI reaches items through zxlib's viewfunc_getItem_t, whose
+// displayIdx is int8_t. An index above 127 arrives negative and is refused, so
+// items beyond this point cannot be shown even though the parser can render
+// them. Count no further than the screen can reach.
+#define MAX_REVIEW_ITEMS 127
+
 typedef enum {
   root_item_chain_id = 0,
   root_item_account_number,

--- a/app/src/tx_parser.c
+++ b/app/src/tx_parser.c
@@ -111,16 +111,20 @@ parser_error_t tx_getToken(uint16_t token_index, char *out_val,
   // empty strings are considered the first page
   *pageCount = 1;
   if (inLen > 0) {
-    for (uint32_t i = 0; i < array_length(value_substitutions); i++) {
-      const char *str1 = (const char *)PIC(value_substitutions[i].str1);
-      const char *str2 = (const char *)PIC(value_substitutions[i].str2);
-      const uint16_t str1Len = strlen(str1);
-      const uint16_t str2Len = strlen(str2);
+    // Only msgs/N/type carries an amino type name. Substituting anywhere else
+    // lets an attacker-chosen memo or address render as an action word.
+    if (is_msg_type_field(parser_tx_obj.tx_json.query.out_key)) {
+      for (uint32_t i = 0; i < array_length(value_substitutions); i++) {
+        const char *str1 = (const char *)PIC(value_substitutions[i].str1);
+        const char *str2 = (const char *)PIC(value_substitutions[i].str2);
+        const uint16_t str1Len = strlen(str1);
+        const uint16_t str2Len = strlen(str2);
 
-      if (inLen == str1Len && strncmp(inValue, str1, str1Len) == 0) {
-        inValue = str2;
-        inLen = str2Len;
-        break;
+        if (inLen == str1Len && strncmp(inValue, str1, str1Len) == 0) {
+          inValue = str2;
+          inLen = str2Len;
+          break;
+        }
       }
     }
     pageStringExt(out_val, out_val_len, inValue, inLen, pageIdx, pageCount);

--- a/app/src/tx_validate.c
+++ b/app/src/tx_validate.c
@@ -37,6 +37,44 @@ int8_t is_space(char c) {
   return 0;
 }
 
+// contains_whitespace only inspects the gaps between tokens, so a control byte
+// inside a value is invisible to it. Those bytes are rendered verbatim by the
+// JSON display path, and each consumes a whole line of a review page while
+// costing one character of the budget the page size is derived from, so later
+// bytes can be signed without ever reaching the screen. The canonical compact
+// encoding never emits one.
+//
+// Only string and primitive spans are scanned: an object or array token spans
+// its whole subtree, including the gaps that contains_whitespace owns.
+static parser_error_t contains_control_chars(parsed_json_t *json) {
+  if (json == NULL) {
+    return parser_unexpected_value;
+  }
+
+  for (uint32_t i = 0; i < json->numberOfTokens; i++) {
+    const jsmntok_t *token = &json->tokens[i];
+
+    if (token->type == JSMN_UNDEFINED) {
+      break;
+    }
+    if (token->type != JSMN_STRING && token->type != JSMN_PRIMITIVE) {
+      continue;
+    }
+    if (token->start < 0 || token->end < token->start ||
+        token->end > (int)json->bufferLen) {
+      return parser_unexpected_value;
+    }
+
+    for (int j = token->start; j < token->end; j++) {
+      if ((uint8_t)json->buffer[j] < 0x20) {
+        return parser_unexpected_characters;
+      }
+    }
+  }
+
+  return parser_ok;
+}
+
 parser_error_t contains_whitespace(parsed_json_t *json) {
   if (json == NULL) {
     return parser_unexpected_value;
@@ -256,7 +294,12 @@ parser_error_t tx_validate(parsed_json_t *json) {
     return parser_unexpected_characters;
   }
 
-  parser_error_t err = contains_whitespace(json);
+  parser_error_t err = contains_control_chars(json);
+  if (err != parser_ok) {
+    return err;
+  }
+
+  err = contains_whitespace(json);
   if (err != parser_ok) {
     return err;
   }

--- a/tests/cbor_parse.cpp
+++ b/tests/cbor_parse.cpp
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ *   (c) 2026 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include <gmock/gmock.h>
+
+#include "app_mode.h"
+#include "coin.h"
+#include "common/parser.h"
+#include <vector>
+
+// A SIGN_MODE_TEXTUAL payload is a CBOR map { 1: [ screen, ... ] } where every
+// screen is a map keyed by TITLE(1) / CONTENT(2) / INDENT(3) / EXPERT(4). The
+// whole document comes from the host, so the parser has to be strict about
+// shapes it will never render.
+namespace {
+
+// Wraps screens into the outer `{ 1: [ ... ] }` document.
+std::vector<uint8_t> document(const std::vector<uint8_t> &screens, uint8_t count) {
+  std::vector<uint8_t> out = {0xa1, 0x01, static_cast<uint8_t>(0x80 | count)};
+  out.insert(out.end(), screens.begin(), screens.end());
+  return out;
+}
+
+parser_error_t parse_textual(const std::vector<uint8_t> &blob) {
+  parser_context_t ctx;
+  parser_tx_t tx_obj;
+  memset(&tx_obj, 0, sizeof(tx_obj));
+  tx_obj.tx_type = tx_textual;
+  return parser_parse(&ctx, blob.data(), blob.size(), &tx_obj);
+}
+
+}  // namespace
+
+TEST(CborTextual, MinimalScreenIsAccepted) {
+  // { 1: "t", 2: "c" }
+  const auto blob = document({0xa2, 0x01, 0x61, 't', 0x02, 0x61, 'c'}, 1);
+  EXPECT_EQ(parse_textual(blob), parser_ok);
+}
+
+TEST(CborTextual, EverySchemaFieldIsAccepted) {
+  // { 1: "t", 2: "c", 3: 2, 4: true }
+  const auto blob = document({0xa4, 0x01, 0x61, 't', 0x02, 0x61, 'c', 0x03, 0x02, 0x04, 0xf5}, 1);
+  EXPECT_EQ(parse_textual(blob), parser_ok);
+}
+
+TEST(CborTextual, UnknownKeyIsRejected) {
+  // { 1: "t", 2: "c", 9: "x" } -- key 9 is outside the schema. Skipping it
+  // would step over a value of unknown shape and clear options already set.
+  const auto blob = document({0xa3, 0x01, 0x61, 't', 0x02, 0x61, 'c', 0x09, 0x61, 'x'}, 1);
+  EXPECT_EQ(parse_textual(blob), parser_unexpected_field);
+}
+
+TEST(CborTextual, IndefiniteLengthTitleIsRejected) {
+  // { 1: (_ "t"), 2: "c" } -- an indefinite-length string reports itself as a
+  // text string but cannot be consumed as one chunk.
+  const auto blob = document({0xa2, 0x01, 0x7f, 0x61, 't', 0xff, 0x02, 0x61, 'c'}, 1);
+  EXPECT_EQ(parse_textual(blob), parser_unexpected_type);
+}
+
+TEST(CborTextual, ContainerAsTitleIsRejected) {
+  // { 1: ["t"], 2: "c" } -- a title that is an array rather than a string.
+  const auto blob = document({0xa2, 0x01, 0x81, 0x61, 't', 0x02, 0x61, 'c'}, 1);
+  EXPECT_EQ(parse_textual(blob), parser_unexpected_type);
+}
+
+// The regression this file exists for: cbor_value_advance() recurses once per
+// container nesting level, so a title built from deeply nested arrays used to
+// drive the parser hundreds of frames deep on a device whose whole stack is
+// APP_STACK_MIN_SIZE. Rejection must happen on shape, before any descent.
+TEST(CborTextual, DeeplyNestedTitleIsRejectedWithoutDescending) {
+  for (const size_t depth : {8u, 64u, 512u, 900u}) {
+    std::vector<uint8_t> screen = {0xa2, 0x01};
+    screen.insert(screen.end(), depth, 0x81);  // depth x array(1)
+    screen.push_back(0x60);                    // innermost value: ""
+    screen.insert(screen.end(), {0x02, 0x61, 'x'});
+
+    const auto err = parse_textual(document(screen, 1));
+    EXPECT_NE(err, parser_ok) << "depth " << depth << " was accepted";
+    EXPECT_EQ(err, parser_unexpected_type) << "depth " << depth;
+  }
+}
+
+TEST(CborTextual, DeeplyNestedContentIsRejectedWithoutDescending) {
+  std::vector<uint8_t> screen = {0xa2, 0x01, 0x61, 't', 0x02};
+  screen.insert(screen.end(), 900, 0x81);
+  screen.push_back(0x60);
+
+  EXPECT_EQ(parse_textual(document(screen, 1)), parser_unexpected_type);
+}
+
+TEST(CborTextual, TrailingBytesAreRejected) {
+  auto blob = document({0xa2, 0x01, 0x61, 't', 0x02, 0x61, 'c'}, 1);
+  blob.insert(blob.end(), {0xde, 0xad, 0xbe, 0xef});
+  EXPECT_NE(parse_textual(blob), parser_ok);
+}

--- a/tests/control_bytes.cpp
+++ b/tests/control_bytes.cpp
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ *   (c) 2026 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include <gmock/gmock.h>
+
+#include "app_mode.h"
+#include "coin.h"
+#include "common/parser.h"
+#include <string>
+
+// A canonical SignDoc is the compact form sdk.MustSortJSON emits, so no raw
+// control byte ever appears in one. They matter because the whitespace check
+// only inspects the gaps between tokens, never a token's own span, and the
+// JSON display path renders token bytes verbatim -- so a control byte inside a
+// string value is signed but can be pushed off the review page.
+namespace {
+
+std::string signdoc(const std::string &memo) {
+  return R"({"account_number":"8","chain_id":"cosmoshub-4",)"
+         R"("fee":{"amount":[{"amount":"5000","denom":"uatom"}],"gas":"200000"},)"
+         R"("memo":")" + memo + R"(","msgs":[{"type":"cosmos-sdk/MsgSend","value":{)"
+         R"("amount":[{"amount":"10","denom":"uatom"}],)"
+         R"("from_address":"cosmos1from","to_address":"cosmos1to"}}],"sequence":"1"})";
+}
+
+parser_error_t parse(const std::string &tx) {
+  parser_context_t ctx;
+  parser_tx_t tx_obj;
+  memset(&tx_obj, 0, sizeof(tx_obj));
+  tx_obj.tx_type = tx_json;
+
+  const auto err =
+      parser_parse(&ctx, (const uint8_t *)tx.c_str(), tx.size(), &tx_obj);
+  if (err != parser_ok) {
+    return err;
+  }
+  return parser_validate(&ctx);
+}
+
+}  // namespace
+
+TEST(ControlBytes, CanonicalDocumentIsAccepted) {
+  EXPECT_EQ(parse(signdoc("Zondax.ch")), parser_ok);
+}
+
+// 0x20 is the boundary: a space inside a string value is ordinary content and
+// lives in a token's span, where the whitespace check does not reach. It has
+// always been accepted and must stay that way.
+TEST(ControlBytes, SpaceInsideAStringValueIsStillAccepted) {
+  EXPECT_EQ(parse(signdoc("hello world")), parser_ok);
+}
+
+TEST(ControlBytes, RawNewlineInsideAStringIsRejected) {
+  EXPECT_EQ(parse(signdoc("first\nsecond")), parser_unexpected_characters);
+}
+
+TEST(ControlBytes, RawTabInsideAStringIsRejected) {
+  EXPECT_EQ(parse(signdoc("a\tb")), parser_unexpected_characters);
+}
+
+TEST(ControlBytes, RawCarriageReturnInsideAStringIsRejected) {
+  // The classic overwrite trick: a terminal or renderer honouring CR shows only
+  // what follows it.
+  EXPECT_EQ(parse(signdoc("SAFE LOOKING MEMO\rDRAINED")), parser_unexpected_characters);
+}
+
+TEST(ControlBytes, EveryC0ByteIsRejected) {
+  for (int c = 0x01; c <= 0x1f; c++) {
+    const std::string memo = std::string("a") + static_cast<char>(c) + "b";
+    EXPECT_EQ(parse(signdoc(memo)), parser_unexpected_characters)
+        << "byte 0x" << std::hex << c << " was accepted";
+  }
+}
+
+TEST(ControlBytes, EmbeddedNulIsStillRejected) {
+  // Pre-existing guard: NUL also lets JSMN stop early on a hidden suffix.
+  std::string tx = signdoc("visible");
+  tx.insert(tx.size() / 2, std::string(1, '\0'));
+  EXPECT_EQ(parse(tx), parser_unexpected_characters);
+}
+
+// A memo long enough to paginate, carrying enough newlines that each page would
+// demand far more display lines than a review page renders. This is the shape
+// that hides signed bytes behind the truncation NBGL applies per page.
+TEST(ControlBytes, NewlineFloodedMemoIsRejected) {
+  std::string memo;
+  for (int i = 0; i < 60; i++) {
+    memo += "L" + std::to_string(i) + "\n";
+  }
+  EXPECT_EQ(parse(signdoc(memo)), parser_unexpected_characters);
+}
+
+// Closing the control-byte hole does not address look-alike characters: these
+// are legal UTF-8 and legal JSON, and still render verbatim on the JSON path.
+// Recorded so the gap is not mistaken for covered.
+TEST(ControlBytes, DISABLED_LookalikeCharactersAreStillAccepted) {
+  EXPECT_EQ(parse(signdoc("cosmos1‮reversed")), parser_ok);
+}

--- a/tests/display_limits.cpp
+++ b/tests/display_limits.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ *   (c) 2026 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include <gmock/gmock.h>
+
+#include "app_mode.h"
+#include "coin.h"
+#include "common/parser.h"
+#include "tx_display.h"
+#include <string>
+
+// The review UI addresses items through zxlib's viewfunc_getItem_t, whose
+// displayIdx is int8_t. The parser can render more items than that index can
+// reach, so the item count has to stop where the screen does.
+namespace {
+
+// Distinct delegator and validator per message, so neither the msg-type nor the
+// msg-from grouping collapses screens and the item count grows with the batch.
+std::string batch(size_t messages) {
+  std::string msgs;
+  for (size_t i = 0; i < messages; i++) {
+    if (i > 0) {
+      msgs += ",";
+    }
+    const std::string n = std::to_string(100000 + i);
+    msgs += R"({"type":"cosmos-sdk/MsgWithdrawDelegationReward","value":{)"
+            R"("delegator_address":"cosmos1delegator)" + n + R"(",)"
+            R"("validator_address":"cosmosvaloper1validator)" + n + R"("}})";
+  }
+  return R"({"account_number":"8","chain_id":"cosmoshub-4",)"
+         R"("fee":{"amount":[{"amount":"5000","denom":"uatom"}],"gas":"200000"},)"
+         R"("memo":"","msgs":[)" + msgs + R"(],"sequence":"1"})";
+}
+
+}  // namespace
+
+TEST(DisplayLimits, EveryCountedItemIsReachableThroughTheUiIndex) {
+  app_mode_set_expert(false);
+
+  bool saw_accepted = false;
+  bool saw_rejected = false;
+
+  for (size_t messages = 1; messages <= 80; messages++) {
+    const std::string tx = batch(messages);
+
+    parser_context_t ctx;
+    parser_tx_t tx_obj;
+    memset(&tx_obj, 0, sizeof(tx_obj));
+    tx_obj.tx_type = tx_json;
+
+    auto err = parser_parse(&ctx, (const uint8_t *)tx.c_str(), tx.size(), &tx_obj);
+    if (err == parser_ok) {
+      err = parser_validate(&ctx);
+    }
+
+    if (err != parser_ok) {
+      // Growing the batch may exhaust the token pool before the item count is
+      // reached; only the item-count rejection is asserted on here.
+      if (err == parser_unexpected_number_items) {
+        saw_rejected = true;
+      }
+      continue;
+    }
+
+    saw_accepted = true;
+
+    uint8_t numItems = 0;
+    ASSERT_EQ(parser_getNumItems(&ctx, &numItems), parser_ok);
+    EXPECT_LE(numItems, MAX_REVIEW_ITEMS) << messages << " messages";
+
+    // The invariant that matters: an accepted transaction must not count an
+    // item the UI cannot ask for.
+    for (uint8_t i = 0; i < numItems; i++) {
+      ASSERT_GE((int8_t)i, 0) << "item " << (int)i << " of " << (int)numItems
+                              << " is unreachable through an int8_t index ("
+                              << messages << " messages)";
+    }
+  }
+
+  EXPECT_TRUE(saw_accepted) << "no batch was accepted; the fixture is wrong";
+  EXPECT_TRUE(saw_rejected) << "no batch exceeded the item limit; widen the loop";
+}
+
+TEST(DisplayLimits, OversizedBatchIsRejectedNotTruncated) {
+  app_mode_set_expert(false);
+
+  const std::string tx = batch(70);
+
+  parser_context_t ctx;
+  parser_tx_t tx_obj;
+  memset(&tx_obj, 0, sizeof(tx_obj));
+  tx_obj.tx_type = tx_json;
+
+  auto err = parser_parse(&ctx, (const uint8_t *)tx.c_str(), tx.size(), &tx_obj);
+  if (err == parser_ok) {
+    err = parser_validate(&ctx);
+  }
+
+  // A batch this size cannot be reviewed in full, so it must not be signed at
+  // all rather than shown up to the point the index runs out.
+  EXPECT_NE(err, parser_ok);
+}

--- a/tests/grouping.cpp
+++ b/tests/grouping.cpp
@@ -1,0 +1,156 @@
+/*******************************************************************************
+ *   (c) 2026 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include <gmock/gmock.h>
+
+#include "app_mode.h"
+#include "coin.h"
+#include "common.h"
+#include "common/parser.h"
+#include <algorithm>
+#include <string>
+#include <vector>
+
+// A batch of identical messages collapses its repeated Type and From screens
+// into one. That is only sound while "identical" means the same signed bytes:
+// several distinct amino types render through value_substitutions to the same
+// friendly label, so comparing what is displayed would collapse messages the
+// chain treats differently.
+namespace {
+
+std::string staking_msg(const std::string &type, const std::string &validator) {
+  return R"({"type":")" + type + R"(","value":{)"
+         R"("amount":{"amount":"1000000","denom":"uatom"},)"
+         R"("delegator_address":"cosmos1delegator",)"
+         R"("validator_address":")" + validator + R"("}})";
+}
+
+std::string signdoc(const std::vector<std::string> &msgs) {
+  std::string joined;
+  for (size_t i = 0; i < msgs.size(); i++) {
+    if (i > 0) {
+      joined += ",";
+    }
+    joined += msgs[i];
+  }
+  return R"({"account_number":"8","chain_id":"cosmoshub-4",)"
+         R"("fee":{"amount":[{"amount":"5000","denom":"uatom"}],"gas":"200000"},)"
+         R"("memo":"","msgs":[)" + joined + R"(],"sequence":"1"})";
+}
+
+std::vector<std::string> render(const std::string &tx) {
+  parser_context_t ctx;
+  parser_tx_t tx_obj;
+  memset(&tx_obj, 0, sizeof(tx_obj));
+  tx_obj.tx_type = tx_json;
+
+  auto err = parser_parse(&ctx, (const uint8_t *)tx.c_str(), tx.size(), &tx_obj);
+  if (err != parser_ok) {
+    return {};
+  }
+  if (parser_validate(&ctx) != parser_ok) {
+    return {};
+  }
+  return dumpUI(&ctx, 40, 40);
+}
+
+// dumpUI emits "<idx> | <key>[ [p/n]] : <value>", one line per page. Count
+// distinct item indices so a paginated value is still one screen.
+size_t count_screens(const std::vector<std::string> &ui, const std::string &key) {
+  std::vector<std::string> seen;
+
+  for (const auto &line : ui) {
+    const auto bar = line.find(" | ");
+    const auto colon = line.find(" : ");
+    if (bar == std::string::npos || colon == std::string::npos || colon < bar) {
+      continue;
+    }
+
+    const std::string idx = line.substr(0, bar);
+    std::string k = line.substr(bar + 3, colon - bar - 3);
+
+    const auto page = k.find(" [");
+    if (page != std::string::npos) {
+      k = k.substr(0, page);
+    }
+    if (k != key) {
+      continue;
+    }
+    if (std::find(seen.begin(), seen.end(), idx) == seen.end()) {
+      seen.push_back(idx);
+    }
+  }
+  return seen.size();
+}
+
+}  // namespace
+
+// The behaviour grouping exists for, and which must not regress.
+TEST(Grouping, IdenticalTypesStillCollapseToOneScreen) {
+  app_mode_set_expert(false);
+
+  const auto ui = render(signdoc({
+      staking_msg("cosmos-sdk/MsgDelegate", "cosmosvaloper1aaa"),
+      staking_msg("cosmos-sdk/MsgDelegate", "cosmosvaloper1bbb"),
+      staking_msg("cosmos-sdk/MsgDelegate", "cosmosvaloper1ccc"),
+  }));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(count_screens(ui, "Type"), 1u);
+  // The differing field is still shown once per message.
+  EXPECT_EQ(count_screens(ui, "Validator"), 3u);
+}
+
+// cosmos-sdk/MsgDelegate is an immediate x/staking delegation;
+// /babylon.epoching.v1.MsgWrappedDelegate is queued to an epoch boundary by
+// x/epoching. Both render as "Delegate", so collapsing on the rendered value
+// would show a single Type screen for two different operations.
+TEST(Grouping, TypesSharingALabelDoNotCollapse) {
+  app_mode_set_expert(false);
+
+  const auto ui = render(signdoc({
+      staking_msg("cosmos-sdk/MsgDelegate", "cosmosvaloper1honest"),
+      staking_msg("/babylon.epoching.v1.MsgWrappedDelegate", "cosmosvaloper1other"),
+  }));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(count_screens(ui, "Type"), 2u)
+      << "two distinct amino types collapsed into one Type screen";
+}
+
+TEST(Grouping, LegacyAndProtoSpellingsOfTheSameTypeDoNotCollapse) {
+  app_mode_set_expert(false);
+
+  const auto ui = render(signdoc({
+      staking_msg("epoching/WrappedDelegate", "cosmosvaloper1honest"),
+      staking_msg("/babylon.epoching.v1.MsgWrappedDelegate", "cosmosvaloper1other"),
+  }));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(count_screens(ui, "Type"), 2u);
+}
+
+TEST(Grouping, DistinctTypesWithDistinctLabelsStillDoNotCollapse) {
+  app_mode_set_expert(false);
+
+  const auto ui = render(signdoc({
+      staking_msg("cosmos-sdk/MsgDelegate", "cosmosvaloper1aaa"),
+      staking_msg("cosmos-sdk/MsgUndelegate", "cosmosvaloper1bbb"),
+  }));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(count_screens(ui, "Type"), 2u);
+}

--- a/tests/substitution.cpp
+++ b/tests/substitution.cpp
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ *   (c) 2026 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ********************************************************************************/
+
+#include <gmock/gmock.h>
+
+#include "app_mode.h"
+#include "coin.h"
+#include "common.h"
+#include "common/parser.h"
+#include <string>
+#include <vector>
+
+// value_substitutions turns an amino type into a readable action word. It is
+// meant for msgs/N/type only: applied to any value, a field whose contents
+// happen to equal a table entry is rewritten, so the screen shows a word that
+// is not what was signed.
+namespace {
+
+std::string send_msg(const std::string &to, const std::string &memo) {
+  return R"({"account_number":"8","chain_id":"cosmoshub-4",)"
+         R"("fee":{"amount":[{"amount":"5000","denom":"uatom"}],"gas":"200000"},)"
+         R"("memo":")" + memo + R"(","msgs":[{"type":"cosmos-sdk/MsgSend","value":{)"
+         R"("amount":[{"amount":"10","denom":"uatom"}],)"
+         R"("from_address":"cosmos1from","to_address":")" + to + R"("}}],"sequence":"1"})";
+}
+
+std::vector<std::string> render(const std::string &tx) {
+  parser_context_t ctx;
+  parser_tx_t tx_obj;
+  memset(&tx_obj, 0, sizeof(tx_obj));
+  tx_obj.tx_type = tx_json;
+
+  auto err = parser_parse(&ctx, (const uint8_t *)tx.c_str(), tx.size(), &tx_obj);
+  if (err != parser_ok) {
+    return {};
+  }
+  if (parser_validate(&ctx) != parser_ok) {
+    return {};
+  }
+  return dumpUI(&ctx, 40, 40);
+}
+
+// Joins every page of the screen with the given key.
+std::string value_of(const std::vector<std::string> &ui, const std::string &key) {
+  std::string joined;
+  for (const auto &line : ui) {
+    const auto bar = line.find(" | ");
+    const auto colon = line.find(" : ");
+    if (bar == std::string::npos || colon == std::string::npos || colon < bar) {
+      continue;
+    }
+    std::string k = line.substr(bar + 3, colon - bar - 3);
+    const auto page = k.find(" [");
+    if (page != std::string::npos) {
+      k = k.substr(0, page);
+    }
+    if (k == key) {
+      joined += line.substr(colon + 3);
+    }
+  }
+  return joined;
+}
+
+}  // namespace
+
+// The behaviour the table exists for.
+TEST(Substitution, MessageTypeIsStillRenderedAsAnActionWord) {
+  app_mode_set_expert(false);
+  const auto ui = render(send_msg("cosmos1to", "hello"));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(value_of(ui, "Type"), "Send");
+}
+
+TEST(Substitution, RecipientMatchingATypeNameIsRenderedVerbatim) {
+  app_mode_set_expert(false);
+  const std::string type_lookalike = "/babylon.epoching.v1.MsgWrappedDelegate";
+  const auto ui = render(send_msg(type_lookalike, "hello"));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(value_of(ui, "To"), type_lookalike)
+      << "recipient was rewritten as an action word";
+  EXPECT_EQ(value_of(ui, "Type"), "Send");
+}
+
+TEST(Substitution, MemoMatchingATypeNameIsRenderedVerbatim) {
+  app_mode_set_expert(false);
+  const auto ui = render(send_msg("cosmos1to", "cosmos-sdk/MsgSend"));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(value_of(ui, "Memo"), "cosmos-sdk/MsgSend");
+}
+
+TEST(Substitution, OrdinaryValuesAreUnaffected) {
+  app_mode_set_expert(false);
+  const auto ui = render(send_msg("cosmos1to", "hello"));
+
+  ASSERT_FALSE(ui.empty());
+  EXPECT_EQ(value_of(ui, "To"), "cosmos1to");
+  EXPECT_EQ(value_of(ui, "Memo"), "hello");
+  EXPECT_EQ(value_of(ui, "From"), "cosmos1from");
+}

--- a/tests/testcases/manual.json
+++ b/tests/testcases/manual.json
@@ -1004,8 +1004,7 @@
     },
     "parsingErr": "No error",
     "validationErr": "JSON Missing chain_id",
-    "expected": [
-    ],
+    "expected": [],
     "expert": true
   },
   {
@@ -2212,49 +2211,70 @@
     "expert": true
   },
   {
-		"name": "huge_test",
-		"tx": {
-			"account_number": "1",
-			"chain_id": "my-chain",
-			"fee": { "amount": [{ "amount": "2000", "denom": "uatom" }], "gas": "100000", "granter": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs", "payer": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs" },
-			"memo": "\\u003e ⚛️\\u269B⚛️     ",
-			"msgs": [
-				{
-					"type": "cosmos-sdk/MsgExec",
-					"value": {
-						"grantee": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs",
-						"msgs": [
-							{
-								"type": "cosmos-sdk/MsgSend",
-								"value": {
-									"amount": [{ "amount": "10000000", "denom": "uatom" }],
-									"from_address": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs",
-									"to_address": "cosmos1ejrf4cur2wy6kfurg9f2jppp2h3afe5h6pkh5t"
-								}
-							}
-						]
-					}
-				},
-				{
-					"type": "cosmos-sdk/v1/MsgVote",
-					"value": {
-						"metadata": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Also it ends in  a single ampersand @",
-						"option": 1,
-						"proposal_id": "1",
-						"voter": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs"
-					}
-				}
-			],
-			"sequence": "2",
-			"timeout_height": "20",
-			"tip": {
-				"amount": [
-					{ "amount": "20000", "denom": "uatom" },
-					{ "amount": "30000", "denom": "uosmo" }
-				],
-				"tipper": "cosmos1ejrf4cur2wy6kfurg9f2jppp2h3afe5h6pkh5t"
-			}
-		},
+    "name": "huge_test",
+    "tx": {
+      "account_number": "1",
+      "chain_id": "my-chain",
+      "fee": {
+        "amount": [
+          {
+            "amount": "2000",
+            "denom": "uatom"
+          }
+        ],
+        "gas": "100000",
+        "granter": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs",
+        "payer": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs"
+      },
+      "memo": "\\u003e ⚛️\\u269B⚛️     ",
+      "msgs": [
+        {
+          "type": "cosmos-sdk/MsgExec",
+          "value": {
+            "grantee": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs",
+            "msgs": [
+              {
+                "type": "cosmos-sdk/MsgSend",
+                "value": {
+                  "amount": [
+                    {
+                      "amount": "10000000",
+                      "denom": "uatom"
+                    }
+                  ],
+                  "from_address": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs",
+                  "to_address": "cosmos1ejrf4cur2wy6kfurg9f2jppp2h3afe5h6pkh5t"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "cosmos-sdk/v1/MsgVote",
+          "value": {
+            "metadata": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Also it ends in  a single ampersand @",
+            "option": 1,
+            "proposal_id": "1",
+            "voter": "cosmos1ulav3hsenupswqfkw2y3sup5kgtqwnvqa8eyhs"
+          }
+        }
+      ],
+      "sequence": "2",
+      "timeout_height": "20",
+      "tip": {
+        "amount": [
+          {
+            "amount": "20000",
+            "denom": "uatom"
+          },
+          {
+            "amount": "30000",
+            "denom": "uosmo"
+          }
+        ],
+        "tipper": "cosmos1ejrf4cur2wy6kfurg9f2jppp2h3afe5h6pkh5t"
+      }
+    },
     "parsingErr": "No error",
     "validationErr": "No error",
     "expected": [
@@ -2301,12 +2321,12 @@
       "17 | Tipper [1/2] : cosmos1ejrf4cur2wy6kfurg9f2jppp2h3afe5h",
       "17 | Tipper [2/2] : 6pkh5t",
       "18 | Timeout Height : 20"
-   ],
+    ],
     "expert": true
-	},
+  },
   {
     "name": "MsgSetWithdrawAddress",
-    "tx":{
+    "tx": {
       "account_number": "8",
       "chain_id": "testing",
       "fee": {
@@ -2361,25 +2381,29 @@
   {
     "name": "Gaia_Sign_00",
     "tx": {
-      "account_number":"8",
-      "sequence":"2",
-      "chain_id":"my-chain",
-      "memo":"A B C",
-      "fee":{
-          "amount":[],
-          "gas":"200000"
+      "account_number": "8",
+      "sequence": "2",
+      "chain_id": "my-chain",
+      "memo": "A B C",
+      "fee": {
+        "amount": [],
+        "gas": "200000"
       },
-      "msgs":[{
-        "type":"cosmos-sdk/MsgDeposit",
-        "value":{
-          "amount":[{
-            "amount":"10",
-            "denom":"stake"
-            }],
-          "depositor":"cosmos1xl2256vdh0j68khz9wq88hnyqcq0f5f4za2480",
-          "proposal_id":"1"
+      "msgs": [
+        {
+          "type": "cosmos-sdk/MsgDeposit",
+          "value": {
+            "amount": [
+              {
+                "amount": "10",
+                "denom": "stake"
+              }
+            ],
+            "depositor": "cosmos1xl2256vdh0j68khz9wq88hnyqcq0f5f4za2480",
+            "proposal_id": "1"
+          }
         }
-      }]
+      ]
     },
     "parsingErr": "No error",
     "validationErr": "No error",
@@ -2401,32 +2425,37 @@
   {
     "name": "Gaia_Sign_01",
     "tx": {
-      "account_number":"123",
-      "sequence":"8",
-      "chain_id":"my-chain",
-      "fee":{
-        "amount":[{
-          "denom":"uatom",
-          "amount":"54"
-        }],
-        "gas":"106309",
+      "account_number": "123",
+      "sequence": "8",
+      "chain_id": "my-chain",
+      "fee": {
+        "amount": [
+          {
+            "denom": "uatom",
+            "amount": "54"
+          }
+        ],
+        "gas": "106309",
         "granter": "cosmosaccaddr1d9h8xxxGRANTER",
         "payer": "cosmosaccaddr1d9h8qatxxPAYER"
       },
-
-      "msgs":[{
-        "type":"cosmos-sdk/MsgDeposit",
-        "value":{
-          "amount":[{
-            "amount":"255000000",
-            "denom":"uatom"
-          }],
-          "depositor":"cosmos1849m9wncrqp6v4tkss6a3j8uzvuv0cp7wcgvqa",
-          "proposal_id":"44"
+      "msgs": [
+        {
+          "type": "cosmos-sdk/MsgDeposit",
+          "value": {
+            "amount": [
+              {
+                "amount": "255000000",
+                "denom": "uatom"
+              }
+            ],
+            "depositor": "cosmos1849m9wncrqp6v4tkss6a3j8uzvuv0cp7wcgvqa",
+            "proposal_id": "44"
+          }
         }
-      }],
-      "memo":"",
-      "timeout_height":"0"
+      ],
+      "memo": "",
+      "timeout_height": "0"
     },
     "parsingErr": "No error",
     "validationErr": "No error",
@@ -2453,56 +2482,56 @@
       "account_number": "10",
       "chain_id": "chain-WiONzW",
       "fee": {
-          "amount": [],
-          "gas": "200000"
+        "amount": [],
+        "gas": "200000"
       },
       "memo": "",
       "msgs": [
-          {
-              "type": "cosmos-sdk/MsgMultiSend",
-              "value": {
-                  "inputs": [
-                      {
-                          "address": "cosmos1w4efqfklkezgyt6lncjdwxncrzyzpr2efzcqal",
-                          "coins": [
-                              {
-                                  "amount": "30",
-                                  "denom": "stake"
-                              }
-                          ]
-                      }
-                  ],
-                  "outputs": [
-                      {
-                          "address": "cosmos184hgxlzat3qhm7p28563w4jyw4aa3wcgnj6gtv",
-                          "coins": [
-                              {
-                                  "amount": "10",
-                                  "denom": "stake"
-                              }
-                          ]
-                      },
-                      {
-                          "address": "cosmos1pfyz36qx8z8dm8ktd75mwx5j5vsmkzfn7wrgp9",
-                          "coins": [
-                              {
-                                  "amount": "10",
-                                  "denom": "stake"
-                              }
-                          ]
-                      },
-                      {
-                          "address": "cosmos1xu388ml6krya3ysmlrup2ylxjtzhl4hlaem3ng",
-                          "coins": [
-                              {
-                                  "amount": "10",
-                                  "denom": "stake"
-                              }
-                          ]
-                      }
-                  ]
+        {
+          "type": "cosmos-sdk/MsgMultiSend",
+          "value": {
+            "inputs": [
+              {
+                "address": "cosmos1w4efqfklkezgyt6lncjdwxncrzyzpr2efzcqal",
+                "coins": [
+                  {
+                    "amount": "30",
+                    "denom": "stake"
+                  }
+                ]
               }
+            ],
+            "outputs": [
+              {
+                "address": "cosmos184hgxlzat3qhm7p28563w4jyw4aa3wcgnj6gtv",
+                "coins": [
+                  {
+                    "amount": "10",
+                    "denom": "stake"
+                  }
+                ]
+              },
+              {
+                "address": "cosmos1pfyz36qx8z8dm8ktd75mwx5j5vsmkzfn7wrgp9",
+                "coins": [
+                  {
+                    "amount": "10",
+                    "denom": "stake"
+                  }
+                ]
+              },
+              {
+                "address": "cosmos1xu388ml6krya3ysmlrup2ylxjtzhl4hlaem3ng",
+                "coins": [
+                  {
+                    "amount": "10",
+                    "denom": "stake"
+                  }
+                ]
+              }
+            ]
           }
+        }
       ],
       "sequence": "16"
     },
@@ -2529,8 +2558,7 @@
       "13 | Gas : 200000"
     ],
     "expert": true
-
-},
+  },
   {
     "name": "babylonWrappedDelegate",
     "tx": {
@@ -2630,7 +2658,58 @@
       "9 | Gas : 200000"
     ],
     "expert": false
+  },
+  {
+    "name": "babylonWrappedBeginRedelegate",
+    "tx": {
+      "account_number": "6571",
+      "chain_id": "bbn-1",
+      "fee": {
+        "amount": [
+          {
+            "amount": "5000",
+            "denom": "ubbn"
+          }
+        ],
+        "gas": "200000"
+      },
+      "memo": "Zondax.ch",
+      "msgs": [
+        {
+          "type": "/babylon.epoching.v1.MsgWrappedBeginRedelegate",
+          "value": {
+            "msg": {
+              "amount": {
+                "amount": "1000000",
+                "denom": "ubbn"
+              },
+              "delegator_address": "bbn102hty0jv2s29lyc4u0tv97z9v298e24t3vwtpl",
+              "validator_dst_address": "bbnvaloper1dst7wu3sxgt9m5s03xfytvz7aaaaaaaaaa",
+              "validator_src_address": "bbnvaloper1grgelyng2v6v3t8z87wu3sxgt9m5s03xfytvz7"
+            }
+          }
+        }
+      ],
+      "sequence": "1"
+    },
+    "parsingErr": "No error",
+    "validationErr": "No error",
+    "expected": [
+      "0 | Chain ID : bbn-1",
+      "1 | Account : 6571",
+      "2 | Sequence : 1",
+      "3 | Type : Redelegate",
+      "4 | Amount : 1000000 ubbn",
+      "5 | Delegator [1/2] : bbn102hty0jv2s29lyc4u0tv97z9v298e24t3vw",
+      "5 | Delegator [2/2] : tpl",
+      "6 | Validator Dest [1/2] : bbnvaloper1dst7wu3sxgt9m5s03xfytvz7aaaa",
+      "6 | Validator Dest [2/2] : aaaaaa",
+      "7 | Validator Source [1/2] : bbnvaloper1grgelyng2v6v3t8z87wu3sxgt9m5",
+      "7 | Validator Source [2/2] : s03xfytvz7",
+      "8 | Memo : Zondax.ch",
+      "9 | Fee : 5000 ubbn",
+      "10 | Gas : 200000"
+    ],
+    "expert": false
   }
-
-
 ]

--- a/tests_zemu/tests/apdu.test.ts
+++ b/tests_zemu/tests/apdu.test.ts
@@ -1,0 +1,150 @@
+/** ******************************************************************************
+ *  (c) 2018 - 2026 Zondax AG
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************* */
+
+import Zemu from '@zondax/zemu'
+import { AMINO_JSON_TX, defaultOptions, DEVICE_MODELS } from './common'
+
+jest.setTimeout(180000)
+
+const CLA = 0x55
+
+const INS_GET_VERSION = 0x00
+const INS_SIGN_SECP256K1 = 0x02
+const INS_GET_ADDR_SECP256K1 = 0x04
+
+const P1_INIT = 0x00
+const P1_ADD = 0x01
+const P1_LAST = 0x02
+const P1_BAD = 0x03
+
+const SW_OK = 0x9000
+const SW_WRONG_LENGTH = 0x6700
+const SW_DATA_INVALID = 0x6984
+const SW_COMMAND_NOT_ALLOWED = 0x6986
+const SW_INVALID_P1P2 = 0x6b00
+const SW_INS_NOT_SUPPORTED = 0x6d00
+const SW_CLA_NOT_SUPPORTED = 0x6e00
+
+// Accept every status word we assert on, so a wrong-but-known code surfaces as
+// a readable expectation failure instead of a TransportStatusError.
+const ACCEPTED_STATUS = [
+  SW_OK,
+  SW_WRONG_LENGTH,
+  SW_DATA_INVALID,
+  SW_COMMAND_NOT_ALLOWED,
+  SW_INVALID_P1P2,
+  SW_INS_NOT_SUPPORTED,
+  SW_CLA_NOT_SUPPORTED,
+]
+
+// m/44'/118'/0'/0/0 as five little-endian uint32 words, the layout extractHDPath
+// memcpy's straight into hdPath.
+const HDPATH = Buffer.from('2c00008076000080000000800000000000000000', 'hex')
+
+// Arbitrary SignDoc fragment. This suite never completes a transaction, so the
+// payload only has to be non-empty.
+const CHUNK = Buffer.from('7b226163636f756e745f6e756d626572223a223022', 'hex')
+
+const GET_ADDR_ARGS = Buffer.concat([Buffer.from([6]), Buffer.from('cosmos'), HDPATH])
+
+// Zemu wraps the transport in a proxy that raises TransportError for any status
+// word other than 0x9000, regardless of the accepted-status list handed to the
+// underlying transport. This suite asserts on rejections, so unwrap it back into
+// a plain status word.
+async function sw(transport: any, cla: number, ins: number, p1: number, p2: number, data: Buffer): Promise<number> {
+  try {
+    const resp = await transport.send(cla, ins, p1, p2, data, ACCEPTED_STATUS)
+    return resp.readUInt16BE(resp.length - 2)
+  } catch (e: any) {
+    if (typeof e?.statusCode === 'number') {
+      return e.statusCode
+    }
+    throw e
+  }
+}
+
+const hex = (v: number) => `0x${v.toString(16)}`
+
+describe('APDU state machine', function () {
+  // One container per device: every assertion below is a pure APDU exchange, and
+  // the sequence is ordered so each step leaves the state the next one needs.
+  // Spinning up a simulator per assertion would mean 45 containers and starves
+  // the runner into start-up timeouts.
+  test.concurrent.each(DEVICE_MODELS)('chunk sequencing is enforced', async function (m) {
+    const sim = new Zemu(m.path)
+    try {
+      await sim.start({ ...defaultOptions, model: m.name })
+      const t = sim.getTransport()
+      const check = (actual: number, expected: number, what: string) =>
+        expect(`${what} -> ${hex(actual)}`).toEqual(`${what} -> ${hex(expected)}`)
+
+      // --- device idle: nothing may be appended to a flow that never started ---
+      check(await sw(t, CLA, INS_SIGN_SECP256K1, P1_ADD, AMINO_JSON_TX, CHUNK), SW_COMMAND_NOT_ALLOWED, 'add without init')
+      check(
+        await sw(t, CLA, INS_SIGN_SECP256K1, P1_LAST, AMINO_JSON_TX, CHUNK),
+        SW_COMMAND_NOT_ALLOWED,
+        'last without init',
+      )
+
+      // --- dispatcher rejects malformed requests ---
+      check(await sw(t, CLA, INS_SIGN_SECP256K1, P1_BAD, AMINO_JSON_TX, CHUNK), SW_INVALID_P1P2, 'unknown payload type')
+      check(await sw(t, CLA, 0x99, 0x00, 0x00, CHUNK), SW_INS_NOT_SUPPORTED, 'unknown instruction')
+      check(await sw(t, 0x44, INS_GET_VERSION, 0x00, 0x00, CHUNK), SW_CLA_NOT_SUPPORTED, 'unknown class')
+
+      // One payload byte: past the OFFSET_DATA guard, short of the five uint32
+      // words extractHDPath needs.
+      check(
+        await sw(t, CLA, INS_SIGN_SECP256K1, P1_INIT, AMINO_JSON_TX, Buffer.from([0x00])),
+        SW_WRONG_LENGTH,
+        'truncated hd path',
+      )
+      // No payload at all: rx stops exactly at OFFSET_DATA.
+      check(
+        await sw(t, CLA, INS_SIGN_SECP256K1, P1_INIT, AMINO_JSON_TX, Buffer.alloc(0)),
+        SW_DATA_INVALID,
+        'empty init payload',
+      )
+
+      // --- a flow is now in progress and owns the device ---
+      check(await sw(t, CLA, INS_SIGN_SECP256K1, P1_INIT, AMINO_JSON_TX, HDPATH), SW_OK, 'init')
+      check(
+        await sw(t, CLA, INS_SIGN_SECP256K1, P1_INIT, AMINO_JSON_TX, HDPATH),
+        SW_COMMAND_NOT_ALLOWED,
+        'second init cannot restart a flow in progress',
+      )
+      check(
+        await sw(t, CLA, INS_GET_ADDR_SECP256K1, 0x00, 0x00, GET_ADDR_ARGS),
+        SW_COMMAND_NOT_ALLOWED,
+        'get address while receiving',
+      )
+      check(await sw(t, CLA, INS_SIGN_SECP256K1, P1_ADD, AMINO_JSON_TX, CHUNK), SW_OK, 'add after init')
+
+      // --- an unrelated error must abort a half-received transaction ---
+      // The buffered chunks were accepted under the HD path and HRP that INIT
+      // installed, so an aborted flow must not be resumable against new ones.
+      // handleApdu keeps resetting TX_STATE_RECEIVING on error and only holds
+      // the state while a review is on screen; this pins that split.
+      check(await sw(t, CLA, INS_SIGN_SECP256K1, P1_BAD, AMINO_JSON_TX, CHUNK), SW_INVALID_P1P2, 'error during receive')
+      check(
+        await sw(t, CLA, INS_SIGN_SECP256K1, P1_ADD, AMINO_JSON_TX, CHUNK),
+        SW_COMMAND_NOT_ALLOWED,
+        'add after an aborted flow',
+      )
+    } finally {
+      await sim.close()
+    }
+  })
+})


### PR DESCRIPTION
Seven changes, one commit each, every one carrying its own tests.

### Request handling

- **`fix(apdu)`** — the processing state is kept while a review is on screen. It was previously cleared by any command error, including ones raised by the dispatcher before a handler runs, which let a following `P1_INIT` rebind `hdPath`, the address encoding and the transaction buffer under a review already displayed. Errors during chunk reception still abort the flow as before. The state is now also claimed only after `view_review_show()` returns, so a failure bringing the review up leaves the app idle rather than locked.

### Parsing

- **`fix(cbor)`** — screen field types are validated before being stepped over. Unrecognised keys were skipped by advancing past a value of unknown shape, and `cbor_value_advance()` recurses once per container nesting level. Title and content must now be definite-length text strings on the parse pass, matching what the display pass already reads, and the recursion limit is capped at the depth the schema needs in both the device and host builds.
- **`fix(validate)`** — raw control bytes inside JSON values are rejected. The whitespace check only inspects the gaps between tokens, so bytes below `0x20` inside a value were never seen. A canonical SignDoc never carries one.

### Review rendering

- **`fix(display)` item count** — the count is bounded by what the UI index can address. `viewfunc_getItem_t` takes an `int8_t`, so items past 127 could not be requested; they were previously counted and then omitted from the review.
- **`fix(display)` grouping** — repeated screens are collapsed on the token bytes rather than the rendered string. Nine amino types render to three labels, so a batch mixing `cosmos-sdk/MsgDelegate` with the x/epoching wrapped form previously showed one Type screen for two different operations.
- **`fix(display)` key buffer** — sized for the longest substituted key path. `msgs/value/msg/validator_src_address` (36 chars) exceeded the buffer, so the wrapped redelegate showed two raw JSON paths differing by one character instead of "Validator Source" / "Validator Dest". Adds the missing `babylonWrappedBeginRedelegate` vector, the only wrapped shape without one.
- **`fix(display)` substitutions** — the type table is applied only to `msgs/N/type`. It previously ran on every value, so a recipient or memo matching a table entry rendered as an action word.

Host tests go from 163 to 183, plus a new APDU-level zemu suite. Each commit builds and passes on its own.
